### PR TITLE
Support for no-sugar

### DIFF
--- a/deck.py
+++ b/deck.py
@@ -29,8 +29,8 @@ try:
     from sugar3.activity import activity
     bundle_path = activity.get_bundle_path()
 except:
-    bundle_path = os.path.expanduser(os.path.join('~', 'Activities',
-                                                  'WordDimensions.activity'))
+    bundle_path = os.path.dirname(os.path.realpath(__file__))
+
 
 class Deck:
 


### PR DESCRIPTION
How "deck.py" is on "bundle_path", I set bundle_path to deck.py parent directory.